### PR TITLE
cast libc::VX_RTP_NAME_LENGTH to usize as it's type has been change t…

### DIFF
--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -405,7 +405,7 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
                 use libc;
                 use core::mem;
                 
-                const N: usize = libc::VX_RTP_NAME_LENGTH + 1;
+                const N: usize = libc::VX_RTP_NAME_LENGTH as usize + 1;
                 static mut BUF: [libc::c_char; N] = [0; N];
                 
                 let mut rtp_desc : libc::RTP_DESC = mem::zeroed();


### PR DESCRIPTION
…o c_int in libc

r? @maya-cm
cc @n-salim